### PR TITLE
CLDR-17028 fix for formatter workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .git
-          key: git-${{ github.base_ref }}-${{ github.head_ref }}
+          key: git-${{ github.base_ref }}-${{ github.sha }}
           restore-keys: |
-            git-${{ github.base_ref }}-${{ github.head_ref }}
+            git-${{ github.base_ref }}-${{ github.sha }}
             git-${{ github.base_ref }}
             git-
       - name: Checkout CLDR


### PR DESCRIPTION
- workflow cache seems to not allow commas in branch names https://github.com/actions/cache/issues/1225
- workaround by using sha instead of branch name

fix for https://github.com/unicode-org/cldr/pull/3211 - remember to merge using rebase!